### PR TITLE
Feature/grunt bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ node_js:
   - "0.10"
 env:
   global:
-    - secure: FLjCmIxmFRpPwOaivZNhX73TLYmOXmOhOH7T1pkac//gbFFpETKd+UhgCFeiQqV2itSHLTAkDVpf4YD8qk6MXpPlODfyqhlQlRlFoPb8ihcdv3eAbYpWDifALeo3s/dKwFtqIfhoI4gP4bVF92lsAaC6QQKMJuTv5MQq5o96HBU=
-    - secure: NB9+y80rG+r7nvwBHs5Ec+l9DP7eGwUyTY0+o/ATgAItr4Key6dd00oZIYjSGfZBle5BRrYZnERmNE+4d2NaaemmGssnA/7c9pHrat1SUODiHdg9wOhmQxiA3c0AqBGnEiUz/jLb1rUZaz80wf+4wYST9Jv+PUmsnS00m0WhOFQ=
+    - secure: RhmfgnPkrCcjOTWkfYFZS5zlBQhte2cAAtjA/bIKH4qhaLsWHHS0ApJ065PJs4H/lfslWSfnRcUpaeFq8hhr/9dMlCxFJc5CTJ2EfmV56NjsiaETtrxHdNVFtZU/DxJnSxnW4revbFkk/mM6JZ+P7XwVv+iitKhx3uRpX2/rKWA=
+    - secure: hmu/VH1viA8oPFjxBrjvnLrNa0PnfXsIKMMv9ZmgpXthdhTtuReD9rPmbnFzNh9MyCkLSZcndJakpDu9SwHVDcs5eyV72fuXHW/0htyN9eNTMyShrNIpOJe6JUqMez7MxQU9J45IJGSvbyEfrbZ20mbGGzJ41KnEZ0IfwODPcMY=
 before_install:
   - npm install -g bower
   - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 install:
   - npm install
 script:
+  - grunt test:development
   - grunt test
   - grunt e2e --ci
 after_success:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -84,7 +84,7 @@ module.exports = function (grunt) {
                     "tests/unit/**/*.js",
                     "tests/unit/**/**/*.js"
                 ],
-                tasks: ["test"]
+                tasks: ["test:development"]
             }
         },
 
@@ -330,6 +330,13 @@ module.exports = function (grunt) {
     ]);
 
     grunt.registerTask("test", [
+        "clean:beforeBuild",
+        "jshint",
+        "uglify",
+        "jasmine:production"
+    ]);
+
+    grunt.registerTask("test:development", [
         "jshint",
         "jasmine:development"
     ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -294,20 +294,21 @@ module.exports = function (grunt) {
 
     grunt.registerTask("build", [
         "clean:beforeBuild",
-        "jshint",
-        "uglify",
-        "jasmine:production",
         "less:production",
-        "copy:images",
-        "copy:partials",
-        "processhtml:production",
-        "yuidoc"
+        "uglify",
+        "copyBuild",
+        "processhtml:production"
     ]);
 
     grunt.registerTask("release", [
         "bump-only",
         "build",
         "bump-commit"
+    ]);
+
+    grunt.registerTask("copyBuild", [
+        "copy:images",
+        "copy:partials"
     ]);
 
     grunt.registerTask("server", [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -91,7 +91,9 @@ module.exports = function (grunt) {
         less: {
             options: {
                 paths: ["app/less/"],
-                cleancss: false
+                cleancss: false,
+                banner: "/*! <%= pkg.name %> - v<%= pkg.version %> - " +
+                    "<%= grunt.template.today(\"yyyy-mm-dd\") %> */\n"
             },
             development: {
                 files: { "app/css/all.css": "app/less/main.less" },
@@ -174,7 +176,9 @@ module.exports = function (grunt) {
         concat: {
             options: {
                 sourceMap: true,
-                separator: ";"
+                separator: ";",
+                banner: "/*! <%= pkg.name %> - v<%= pkg.version %> - " +
+                    "<%= grunt.template.today(\"yyyy-mm-dd\") %> */\n"
             },
             production: {
                 src: [
@@ -189,9 +193,9 @@ module.exports = function (grunt) {
             options: {
                 sourceMap: true,
                 sourceMapIncludeSources: true,
-                enclose: {
-                    window: "window"
-                }
+                enclose: { window: "window" },
+                banner: "/*! <%= pkg.name %> - v<%= pkg.version %> - " +
+                    "<%= grunt.template.today(\"yyyy-mm-dd\") %> */\n"
             },
             production: {
                 files: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -290,6 +290,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-protractor-runner");
     grunt.loadNpmTasks("grunt-protractor-webdriver");
     grunt.loadNpmTasks("grunt-processhtml");
+    grunt.loadNpmTasks('grunt-bump');
 
     grunt.registerTask("build", [
         "clean:beforeBuild",
@@ -301,6 +302,12 @@ module.exports = function (grunt) {
         "copy:partials",
         "processhtml:production",
         "yuidoc"
+    ]);
+
+    grunt.registerTask("release", [
+        "bump-only",
+        "build",
+        "bump-commit"
     ]);
 
     grunt.registerTask("server", [
@@ -338,6 +345,5 @@ module.exports = function (grunt) {
     ]);
 
     grunt.registerTask("default", ["build"]);
-    grunt.registerTask("release", ["build"]);
 
 };

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2010-2014 Google, Inc. http://angularjs.org
+Copyright (c) 2015 SOON_. http://thisissoon.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ grunt build
 
 The build files will then be in the `dist/` directory.
 
+### Creating a new release
+
+To create a new release simply run: 
+
+```
+grunt release --setversion X.Y.Z
+```
+
+Where `X.Y.Z` is the new version number. This will update `package.json` 
+and `bower.json` with the new version number and then run `grunt build` before
+committing the changes to git.
+
+The build files will then be in the `dist/` directory.
+
 
 ## Directory Layout
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "connect-livereload": "~0.5.0",
     "connect-modrewrite": "~0.7.9",
     "coveralls": "~2.11.2",
+    "grunt-bump": "~0.3.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-connect": "~0.9.0",


### PR DESCRIPTION
This PR add's the following:

- grunt bump for easy versioning, to do a release just run `grunt release --setversion x.x.x`
- simplifies the `grunt build` command by removing running unit tests, instead unit test on production code will be run in travis on every push. Locally they can be run using `grunt test`.